### PR TITLE
Update caido download links

### DIFF
--- a/roles/install_tools/tasks/install_caido.yml
+++ b/roles/install_tools/tasks/install_caido.yml
@@ -12,8 +12,8 @@
     dest: "{{ tools_dir }}/Caido/{{ item | basename }}"
     mode: "0755"
   loop:
-    - "https://storage.googleapis.com/caido-releases/v{{ caido_version }}/caido-desktop-v{{ caido_version }}-{{ base_os }}-x86_64.AppImage"
-    - "https://storage.googleapis.com/caido-releases/v{{ caido_version }}/caido-cli-v{{ caido_version }}-{{ base_os }}-x86_64.tar.gz"
+    - "https://caido.download/releases/v{{ caido_version }}/caido-desktop-v{{ caido_version }}-{{ base_os }}-x86_64.AppImage"
+    - "https://caido.download/releases/v{{ caido_version }}/caido-cli-v{{ caido_version }}-{{ base_os }}-x86_64.tar.gz"
 
 - name: Extract cargo CLI
   ansible.builtin.unarchive:


### PR DESCRIPTION
Hi! Creator of Caido here.
We are moving away from GCP and onto our own download domain.
Older links won't work within the next 30 days.
Documentation: https://docs.caido.io/concepts/internals/download.html